### PR TITLE
Override the grammar to allow symbols in the names

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
   <groupId>com.bpodgursky</groupId>
   <artifactId>jbool_expressions</artifactId>
-  <version>1.9-SNAPSHOT</version>
+  <version>1.9.0-W2O-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>jbool_expressions</name>
@@ -44,6 +44,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <gpg.skip>true</gpg.skip>
   </properties>
 
   <dependencies>
@@ -108,6 +109,9 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-gpg-plugin</artifactId>
         <version>1.4</version>
+        <configuration>
+          <skip>${gpg.skip}</skip>
+        </configuration>
         <executions>
           <execution>
             <id>sign-artifacts</id>

--- a/src/main/antlr3/com/bpodgursky/jbool_expressions/parsers/BooleanExpr.g
+++ b/src/main/antlr3/com/bpodgursky/jbool_expressions/parsers/BooleanExpr.g
@@ -16,12 +16,12 @@ package com.bpodgursky.jbool_expressions.parsers;
 
 LPAREN : '(' ;
 RPAREN : ')' ;
-AND : '&';
+AND : '&' | ',';
 OR : '|';
 NOT : '!';
 TRUE : 'true';
 FALSE : 'false';
-NAME : ('A'..'Z' | 'a'..'z' | '_' | '0'..'9')+;
+NAME : ('A'..'Z' | 'a'..'z' | '_' | '0'..'9' | '$' | '%' | ':' | '-' | '.')+;
 QUOTED_NAME : '\''~('\r' | '\n' | '\'')+ '\'';
 WS : ( ' ' | '\t' | '\r' | '\n' )+ { $channel = HIDDEN; };
 


### PR DESCRIPTION
Also skipping gpg by default and versioning as W2O to mark the w2ogroup changes.
